### PR TITLE
feat: add t (type) to messages in api documentation

### DIFF
--- a/api/messageservice.yaml
+++ b/api/messageservice.yaml
@@ -379,6 +379,9 @@ components:
         _id:
           type: string
           example: "M73fE4WhYF4peYB3s"
+        t:
+          type: string
+          example: "room_changed_privacy"
         alias:
           $ref: '#/components/schemas/AliasMessageDTO'
         rid:


### PR DESCRIPTION
* already present in DTO, but not reflected in API
* required for e2ee